### PR TITLE
Use async/await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
+## V 1.3
+
+* Use AsyncParsableCommand and async versions of CoreLocation methods.
+* Update swift-argument-parser.
+* The code in branch `async` now requires Swift 5.5 and macOS 10.15 Catalina and up.
+
 ## V 1.2
 
-* Rolled back Swift tools from 5.2 to 5.1 to support Mojave
+* Rolled back Swift tools from 5.2 to 5.1 to support Mojave.
 
 ## V 1.1
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
-          "version": "0.0.6"
+          "revision": "f3c9084a71ef4376f2fabbdf1d3d90a49f1fabdb",
+          "version": "1.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "now",
     platforms: [
-      .macOS(.v10_12)
+      .macOS(.v10_15)
     ],
     products: [
         .executable(
@@ -16,10 +16,10 @@ let package = Package(
     dependencies: [
       .package(
         url:"https://github.com/apple/swift-argument-parser",
-        .exact("0.0.6")),
+		.upToNextMajor(from: "1.1.2")),
     ],
     targets: [
-        .target(
+        .executableTarget(
             name: "now",
             dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")],
             path: "now/"

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
       .package(
         url:"https://github.com/apple/swift-argument-parser",
-		.upToNextMajor(from: "1.1.2")),
+        .upToNextMajor(from: "1.1.2")),
     ],
     targets: [
         .executableTarget(

--- a/now.xcodeproj/project.pbxproj
+++ b/now.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		8E0CC35324734428008B5432 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0CC35224734428008B5432 /* main.swift */; };
 		8E0CC3592473443C008B5432 /* now in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8E0CC34F24734428008B5432 /* now */; };
 		8E0CC35E2473460C008B5432 /* RuntimeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0CC35D2473460C008B5432 /* RuntimeError.swift */; };
 		8E0CC36024734614008B5432 /* Date+Offsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0CC35F24734614008B5432 /* Date+Offsets.swift */; };
@@ -15,6 +14,7 @@
 		8E10B4A92478326700597641 /* Result+Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E10B4A82478326700597641 /* Result+Utility.swift */; };
 		8E3D88672479A4B700DB2C06 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 8E3D88662479A4B700DB2C06 /* ArgumentParser */; };
 		8E8795962486A8DC0029766B /* LocatedTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8795952486A8DC0029766B /* LocatedTime.swift */; };
+		B38D18FA280706700089F0CE /* Now.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38D18F9280706700089F0CE /* Now.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -32,12 +32,12 @@
 
 /* Begin PBXFileReference section */
 		8E0CC34F24734428008B5432 /* now */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = now; sourceTree = BUILT_PRODUCTS_DIR; };
-		8E0CC35224734428008B5432 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		8E0CC35D2473460C008B5432 /* RuntimeError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeError.swift; sourceTree = "<group>"; };
 		8E0CC35F24734614008B5432 /* Date+Offsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Offsets.swift"; sourceTree = "<group>"; };
 		8E0CC36124734697008B5432 /* PlaceFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceFinder.swift; sourceTree = "<group>"; };
 		8E10B4A82478326700597641 /* Result+Utility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Utility.swift"; sourceTree = "<group>"; };
 		8E8795952486A8DC0029766B /* LocatedTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatedTime.swift; sourceTree = "<group>"; };
+		B38D18F9280706700089F0CE /* Now.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Now.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,7 +71,7 @@
 		8E0CC35124734428008B5432 /* now */ = {
 			isa = PBXGroup;
 			children = (
-				8E0CC35224734428008B5432 /* main.swift */,
+				B38D18F9280706700089F0CE /* Now.swift */,
 				8E0CC35F24734614008B5432 /* Date+Offsets.swift */,
 				8E8795952486A8DC0029766B /* LocatedTime.swift */,
 				8E0CC36124734697008B5432 /* PlaceFinder.swift */,
@@ -145,11 +145,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8E0CC35324734428008B5432 /* main.swift in Sources */,
 				8E8795962486A8DC0029766B /* LocatedTime.swift in Sources */,
 				8E0CC36024734614008B5432 /* Date+Offsets.swift in Sources */,
 				8E10B4A92478326700597641 /* Result+Utility.swift in Sources */,
 				8E0CC36224734697008B5432 /* PlaceFinder.swift in Sources */,
+				B38D18FA280706700089F0CE /* Now.swift in Sources */,
 				8E0CC35E2473460C008B5432 /* RuntimeError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -322,8 +322,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-argument-parser";
 			requirement = {
-				kind = exactVersion;
-				version = 0.0.6;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/now/LocatedTime.swift
+++ b/now/LocatedTime.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-struct LocatedTime: Codable {
+struct LocatedTime: Encodable {
     let version: String = "1"
     let place: String
     let time: String

--- a/now/Now.swift
+++ b/now/Now.swift
@@ -17,7 +17,7 @@ struct Now: AsyncParsableCommand {
         
         Valid time styles: 5PM, 5:30PM, 17:30, 1730. (No spaces.)
         """,
-        version: "1.1"
+        version: "1.3"
     )
 
     @Option(

--- a/now/Now.swift
+++ b/now/Now.swift
@@ -4,7 +4,8 @@ import Foundation
 import ArgumentParser
 
 /// A command that checks the time at remote locations
-struct Now: ParsableCommand {
+@main
+struct Now: AsyncParsableCommand {
     static var configuration = CommandConfiguration(
         discussion: """
         Check the time at a given location, "now Sao Paolo Brazil". Locations
@@ -32,12 +33,12 @@ struct Now: ParsableCommand {
     @Flag(
         name: .shortAndLong,
         help: "Output JSON results.")
-    var json: Bool
+    var json: Bool = false
     
     @Argument(parsing: .remaining)
     var locationInfo: [String]
 
-    func run() throws {
+    func run() async throws {
         guard
             CommandLine.argc > 1
             else { throw CleanExit.helpRequest() }
@@ -47,8 +48,6 @@ struct Now: ParsableCommand {
             else { throw RuntimeError.localRemoteOverlap }
 
         let hint = locationInfo.joined(separator: " ")
-        try PlaceFinder.showTime(from: hint, at: localTime ?? remoteTime, castingTimeToLocal: remoteTime != nil, outputJSON: json)
+        try await PlaceFinder.showTime(from: hint, at: localTime ?? remoteTime, castingTimeToLocal: remoteTime != nil, outputJSON: json)
     }    
 }
-
-Now.main()

--- a/now/PlaceFinder.swift
+++ b/now/PlaceFinder.swift
@@ -18,12 +18,12 @@ enum PlaceFinder {
     /// - Parameter hint: A free-form location indicator, such as a city name, zip code, place of interest.
     /// - Returns: A `PlaceFindingResult` of the geocoded place hint
     static func fetchPlaceMark(from hint: String) async -> PlaceFindingResult {
-		do {
-			let placemarks = try await CLGeocoder().geocodeAddressString(hint)
-			return .success(placemarks)
-		} catch {
-			return .failure(error)
-		}
+        do {
+            let placemarks = try await CLGeocoder().geocodeAddressString(hint)
+            return .success(placemarks)
+        } catch {
+            return .failure(error)
+        }
     }
     
     /// Display a user-localized time (medium style) for a timezone described by freeform text


### PR DESCRIPTION
- Update swift-argument-parser to latest version.
- Use AsyncParsableCommand and async versions of CoreLocation methods.
- Change `LocatedTime`'s conformance to `Encodable` to suppress warning.
- Rename main.swift to Now.swift to be able to use `@main` attribute.